### PR TITLE
fix: isolate chat context between conversations by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -733,17 +733,21 @@ POST /api/chat/completions
 
 ### Behavior
 
-1. **No forced new chat per request:** if `chatId` is omitted, the proxy first tries to restore chat context from the session (IP + User-Agent) or by `conversation_id`, and only then creates a new chat.
+1. **Isolated by default:** if `chatId` is omitted and `conversation_id` is not provided, the proxy does not restore global session context (IP + User-Agent), so chats do not leak into each other.
 
-2. **Both id formats are supported:** `chatId`/`parentId` and `chat_id`/`parent_id`.
+2. **Conversation-aware routing:** if `conversation_id`/`chat_id` is provided, the proxy keeps context inside that scoped conversation.
 
-3. **Force a fresh chat:** send `newChat: true` or `new_chat: true`.
+3. **Legacy global restore is optional:** set `ALLOW_UNSCOPED_SESSION_CHAT_RESTORE=true` to return to old behavior (restore by IP + User-Agent when ids are omitted).
 
-4. **System messages are supported:** `role: "system"` is passed through to the upstream model.
+4. **Both id formats are supported:** `chatId`/`parentId` and `chat_id`/`parent_id`.
 
-5. **Strict JSON parsing:** invalid JSON (for example, single quotes instead of double quotes) returns `400 Invalid JSON`.
+5. **Force a fresh chat:** send `newChat: true` or `new_chat: true`.
 
-6. **Method check:** `GET /api/chat/completions` returns `405`; use `POST`.
+6. **System messages are supported:** `role: "system"` is passed through to the upstream model.
+
+7. **Strict JSON parsing:** invalid JSON (for example, single quotes instead of double quotes) returns `400 Invalid JSON`.
+
+8. **Method check:** `GET /api/chat/completions` returns `405`; use `POST`.
 
 **System message request example:**
 
@@ -821,16 +825,18 @@ POST /api/chat/completions
 }
 ```
 
-3. **Автоматическое сохранение контекста:** Прокси автоматически сохраняет `chatId` и `parentId` в сессии (на основе IP + User-Agent), поэтому OpenWebUI может продолжать диалог без явной передачи этих параметров.
+3. **Изоляция чатов по умолчанию:** без `conversation_id`/`chatId` прокси не восстанавливает общий контекст по IP + User-Agent, чтобы исключить «память» между разными чатами.
 
-4. **Детерминированные chatId:** Для каждого уникального первого сообщения пользователя генерируется стабильный `chatId`, что позволяет OpenWebUI корректно управлять историей диалогов.
+4. **Scoped-контекст для OpenWebUI:** если OpenWebUI передаёт `conversation_id` (или `chat_id`), контекст продолжается внутри этого конкретного диалога.
 
-5. **Поддержка всех эндпоинтов:**
+5. **Legacy fallback при необходимости:** можно вернуть старое поведение через `ALLOW_UNSCOPED_SESSION_CHAT_RESTORE=true`.
+
+6. **Поддержка всех эндпоинтов:**
    - `/api/chat/completions` — OpenAI-совместимый эндпоинт
    - `/api/v1/chat/completions` — альтернативный OpenAI-совместимый эндпоинт
    - `/api/chat` — нативный эндпоинт прокси
 
-6. **Генерация изображений:** Через OpenWebUI можно использовать генерацию изображений через эндпоинт `/api/images/generations` (DALL-E-совместимый API).
+7. **Генерация изображений:** Через OpenWebUI можно использовать генерацию изображений через эндпоинт `/api/images/generations` (DALL-E-совместимый API).
 
 ---
 
@@ -1334,6 +1340,7 @@ print(response.choices[0].message.content)
 | `PORT` | `3264` | Порт HTTP-сервера |
 | `HOST` | `0.0.0.0` | Адрес привязки |
 | `DEFAULT_MODEL` | `qwen-max-latest` | Модель, используемая если не указана в запросе |
+| `ALLOW_UNSCOPED_SESSION_CHAT_RESTORE` | `false` | Разрешить legacy-восстановление контекста по IP + User-Agent, даже без `conversation_id`/`chatId` |
 
 ### Режимы запуска
 

--- a/src/api/routes.js
+++ b/src/api/routes.js
@@ -7,7 +7,7 @@ import { getMappedModel } from './modelMapping.js';
 import { getStsToken, uploadFileToQwen } from './fileUpload.js';
 import { loadHistory, saveHistory } from './chatHistory.js';
 import { generateImage, getAvailableImageModels, checkImageApiAvailability } from './imageGeneration.js';
-import { MAX_FILE_SIZE, UPLOADS_DIR, DEFAULT_MODEL, STREAMING_CHUNK_DELAY } from '../config.js';
+import { MAX_FILE_SIZE, UPLOADS_DIR, DEFAULT_MODEL, STREAMING_CHUNK_DELAY, ALLOW_UNSCOPED_SESSION_CHAT_RESTORE } from '../config.js';
 import multer from 'multer';
 import path from 'path';
 import fs from 'fs';
@@ -141,6 +141,11 @@ function shouldForceNewChat(req) {
     ].some(isTruthyFlag);
 }
 
+function shouldPersistSessionContext(scope = null) {
+    const normalizedScope = normalizeIdValue(scope);
+    return Boolean(normalizedScope) || ALLOW_UNSCOPED_SESSION_CHAT_RESTORE;
+}
+
 // Глобальное хранилище для маппинга между сгенерированными ID и реальными Qwen chatId
 const chatIdMap = new Map();
 
@@ -206,7 +211,9 @@ function isOpenWebUiMetaRequest(messages) {
 // ============================================
 // СЕССИОННАЯ СИСТЕМА ДЛЯ ОТСЛЕЖИВАНИЯ ЧАТОВ
 // ============================================
-// Отслеживаем последний chatId для каждой сессии (по IP + User-Agent)
+// Scoped-сессии (по conversation_id/chat_id) включены всегда.
+// Unscoped fallback по IP + User-Agent работает только в legacy-режиме
+// через ALLOW_UNSCOPED_SESSION_CHAT_RESTORE=true.
 const sessionToChatMap = new Map(); // session-key -> {chatId, parentId, timestamp}
 
 function getSessionKey(req) {
@@ -715,7 +722,7 @@ router.post('/chat/completions', async (req, res) => {
                     effectiveChatId = buildInternalChatIdFromHint(conversationHint);
                     logInfo(`Using client conversation-id key: ${effectiveChatId}`);
                 }
-            } else {
+            } else if (ALLOW_UNSCOPED_SESSION_CHAT_RESTORE) {
                 const savedSession = forceNewChat ? null : getSavedChatId(req);
                 if (savedSession?.chatId) {
                     effectiveChatId = savedSession.chatId;
@@ -732,6 +739,8 @@ router.post('/chat/completions', async (req, res) => {
                         logInfo(`Created new chatId for session: ${effectiveChatId}`);
                     }
                 }
+            } else {
+                logDebug('chatId/conversation_id не переданы, unscoped session fallback отключён');
             }
         }
 
@@ -848,7 +857,9 @@ router.post('/chat/completions', async (req, res) => {
                         mapChatId(effectiveChatId, result.chatId);
                         logDebug(`Маппинг сохранён: ${effectiveChatId} -> ${result.chatId}`);
                     }
-                    saveChatIdForSession(req, result.chatId, result.parentId, conversationScope);
+                    if (shouldPersistSessionContext(conversationScope)) {
+                        saveChatIdForSession(req, result.chatId, result.parentId, conversationScope);
+                    }
                 }
 
                 if (result.error) {
@@ -910,7 +921,9 @@ router.post('/chat/completions', async (req, res) => {
                     mapChatId(effectiveChatId, result.chatId);
                     logDebug(`Маппинг сохранён: ${effectiveChatId} -> ${result.chatId}`);
                 }
-                saveChatIdForSession(req, result.chatId, result.parentId, conversationScope);
+                if (shouldPersistSessionContext(conversationScope)) {
+                    saveChatIdForSession(req, result.chatId, result.parentId, conversationScope);
+                }
             }
 
             if (result.error) {
@@ -1007,7 +1020,7 @@ router.post('/v1/chat/completions', async (req, res) => {
                     effectiveChatId = buildInternalChatIdFromHint(conversationHint);
                     logInfo(`Using client conversation-id key: ${effectiveChatId}`);
                 }
-            } else {
+            } else if (ALLOW_UNSCOPED_SESSION_CHAT_RESTORE) {
                 const savedSession = forceNewChat ? null : getSavedChatId(req);
                 if (savedSession?.chatId) {
                     effectiveChatId = savedSession.chatId;
@@ -1024,6 +1037,8 @@ router.post('/v1/chat/completions', async (req, res) => {
                         logInfo(`Created new chatId for session: ${effectiveChatId}`);
                     }
                 }
+            } else {
+                logDebug('chatId/conversation_id не переданы, unscoped session fallback отключён');
             }
         }
 
@@ -1133,7 +1148,9 @@ router.post('/v1/chat/completions', async (req, res) => {
 
                 // Сохраняем chatId в сессию для следующих запросов
                 if (!isMeta && result.chatId) {
-                    saveChatIdForSession(req, result.chatId, result.parentId, conversationScope);
+                    if (shouldPersistSessionContext(conversationScope)) {
+                        saveChatIdForSession(req, result.chatId, result.parentId, conversationScope);
+                    }
                 }
 
                 if (result.error) {
@@ -1197,7 +1214,9 @@ router.post('/v1/chat/completions', async (req, res) => {
                     mapChatId(effectiveChatId, result.chatId);
                     logDebug(`Маппинг сохранён: ${effectiveChatId} -> ${result.chatId}`);
                 }
-                saveChatIdForSession(req, result.chatId, result.parentId, conversationScope);
+                if (shouldPersistSessionContext(conversationScope)) {
+                    saveChatIdForSession(req, result.chatId, result.parentId, conversationScope);
+                }
             }
 
             if (result.error) {
@@ -1242,7 +1261,9 @@ router.post('/v1/chat/completions', async (req, res) => {
                 // Сохраняем chatId в сессии для последующих запросов от этого клиента
                 if (!isMeta) {
                     try {
-                        saveChatIdForSession(req, result.chatId, result.parentId || result.response_id, conversationScope);
+                        if (shouldPersistSessionContext(conversationScope)) {
+                            saveChatIdForSession(req, result.chatId, result.parentId || result.response_id, conversationScope);
+                        }
                     } catch (e) {
                         logDebug(`Не удалось сохранить chatId в сессии: ${e.message}`);
                     }

--- a/src/config.js
+++ b/src/config.js
@@ -1,6 +1,13 @@
 // config.js — Единый источник конфигурации проекта.
 // Все значения читаются из env-переменных с фоллбэками на дефолты.
 
+function toBoolean(value) {
+    if (typeof value === 'boolean') return value;
+    if (typeof value === 'number') return value === 1;
+    if (typeof value !== 'string') return false;
+    return ['1', 'true', 'yes', 'on'].includes(value.trim().toLowerCase());
+}
+
 // ─── API URLs ────────────────────────────────────────────────────────────────
 const QWEN_BASE_URL = process.env.QWEN_BASE_URL || 'https://chat.qwen.ai';
 
@@ -42,6 +49,7 @@ export const USER_AGENT = process.env.USER_AGENT || 'Mozilla/5.0 (Windows NT 10.
 export const PORT = Number(process.env.PORT) || 3264;
 export const HOST = process.env.HOST || '0.0.0.0';
 export const DEFAULT_MODEL = process.env.DEFAULT_MODEL || 'qwen-max-latest';
+export const ALLOW_UNSCOPED_SESSION_CHAT_RESTORE = toBoolean(process.env.ALLOW_UNSCOPED_SESSION_CHAT_RESTORE);
 
 // ─── Логирование ─────────────────────────────────────────────────────────────
 export const LOG_LEVEL = process.env.LOG_LEVEL || 'info';


### PR DESCRIPTION
## Что и почему

Сейчас прокси может восстанавливать `chatId` из общей сессии (IP + User-Agent), даже если клиент не передал `chatId`/`conversation_id`.
Из-за этого новый чат иногда продолжает контекст из другого диалога.

Этот PR делает изоляцию контекста поведением по умолчанию, чтобы история из других чатов не подмешивалась.

## Что изменено

- Добавлен env-флаг `ALLOW_UNSCOPED_SESSION_CHAT_RESTORE` (по умолчанию `false`).
- В `/api/chat/completions` и `/api/v1/chat/completions` отключено unscoped-восстановление `chatId` при отсутствии `chatId`/`conversation_id`.
- Scoped-контекст через `conversation_id`/`chat_id` сохранён.
- Сохранение `chatId` в session map теперь выполняется только для scoped-кейсов (или при включённом legacy-флаге).
- Обновлена документация в README.

## Обратная совместимость

- Старое поведение можно вернуть через:
`ALLOW_UNSCOPED_SESSION_CHAT_RESTORE=true`

## Как проверить

1. Запустить сервер с дефолтными настройками.
2. Отправить запрос без `chatId` и без `conversation_id`.
3. Отправить второй независимый запрос без id из другого чата/вкладки.
4. Убедиться, что контекст не продолжается между ними.
5. Повторить с `conversation_id` и убедиться, что scoped-контекст сохраняется внутри одного диалога.
6. Повторить с `ALLOW_UNSCOPED_SESSION_CHAT_RESTORE=true` и проверить возврат legacy-поведения.

## Риски

- Клиенты, которые молча рассчитывали на глобальное восстановление контекста без идентификаторов, теперь получат изолированные чаты.
- Для таких клиентов добавлен явный opt-in через env-флаг.
