### PR TITLE
Fix multi-account chat (token desync) and broken default model

### DIFF
--- a/src/api/chat.js
+++ b/src/api/chat.js
@@ -729,7 +729,9 @@ async function handleApiError(response, tokenObj, message, model, chatId, parent
         }
         const { hasValidTokens } = await import('./tokenManager.js');
         if (hasValidTokens() && retryCount < MAX_RETRY_COUNT) {
-            return sendMessage(message, model, chatId, parentId, files, null, null, null, chatType, size, waitForCompletion, retryCount + 1, onChunk);
+            // chatId/parentId сбрасываем: при смене аккаунта старый чат
+            // принадлежит прежнему токену и под новым «не существует».
+            return sendMessage(message, model, null, null, files, null, null, null, chatType, size, waitForCompletion, retryCount + 1, onChunk);
         }
         logError('Не осталось валидных токенов или исчерпаны попытки.');
         return { error: 'Все токены недействительны (401). Требуется повторная авторизация.', chatId };
@@ -753,7 +755,9 @@ async function handleApiError(response, tokenObj, message, model, chatId, parent
         authToken = null;
         const { hasValidTokens } = await import('./tokenManager.js');
         if (hasValidTokens() && retryCount < MAX_RETRY_COUNT) {
-            return sendMessage(message, model, chatId, parentId, files, null, null, null, chatType, size, waitForCompletion, retryCount + 1, onChunk);
+            // chatId/parentId сбрасываем: при смене аккаунта старый чат
+            // принадлежит прежнему токену и под новым «не существует».
+            return sendMessage(message, model, null, null, files, null, null, null, chatType, size, waitForCompletion, retryCount + 1, onChunk);
         }
         return { error: `Все токены заблокированы по лимиту (${hours}ч)`, chatId };
     }
@@ -766,8 +770,17 @@ async function handleApiError(response, tokenObj, message, model, chatId, parent
 export async function sendMessage(message, model = DEFAULT_MODEL, chatId = null, parentId = null, files = null, tools = null, toolChoice = null, systemMessage = null, chatType = 't2t', size = null, waitForCompletion = true, retryCount = 0, onChunk = null) {
     if (!availableModels) availableModels = getAvailableModelsFromFile();
 
+    const browserContext = getBrowserContext();
+    if (!browserContext) return { error: 'Браузер не инициализирован', chatId };
+
+    // Резолвим аккаунт ОДИН раз: одним и тем же токеном создаём чат и
+    // отправляем сообщение — иначе round-robin разнесёт их по разным
+    // аккаунтам и Qwen вернёт «chat is not exist».
+    const tokenObj = await resolveAuthToken(browserContext);
+    if (!tokenObj) return { error: 'Ошибка авторизации: не удалось получить токен', chatId };
+
     if (!chatId) {
-        const newChatResult = await createChatV2(model, 'Новый чат', 0, chatType);
+        const newChatResult = await createChatV2(model, 'Новый чат', 0, chatType, tokenObj);
         if (newChatResult.error) return { error: 'Не удалось создать чат: ' + newChatResult.error };
         chatId = newChatResult.chatId;
         logInfo(`Создан новый чат v2 с ID: ${chatId}`);
@@ -791,12 +804,6 @@ export async function sendMessage(message, model = DEFAULT_MODEL, chatId = null,
         const typeLabels = { t2i: 'изображение', t2v: 'видео' };
         logInfo(`Тип генерации: ${chatType} (${typeLabels[chatType] || chatType})${size ? `, размер: ${size}` : ''}`);
     }
-
-    const browserContext = getBrowserContext();
-    if (!browserContext) return { error: 'Браузер не инициализирован', chatId };
-
-    const tokenObj = await resolveAuthToken(browserContext);
-    if (!tokenObj) return { error: 'Ошибка авторизации: не удалось получить токен', chatId };
 
     let page = null;
     try {
@@ -1005,11 +1012,14 @@ export function getAuthToken() {
 
 // ─── createChatV2 ────────────────────────────────────────────────────────────
 
-export async function createChatV2(model = DEFAULT_MODEL, title = 'Новый чат', retryCount = 0, chatType = 't2t') {
+export async function createChatV2(model = DEFAULT_MODEL, title = 'Новый чат', retryCount = 0, chatType = 't2t', tokenObj = null) {
     const browserContext = getBrowserContext();
     if (!browserContext) return { error: 'Браузер не инициализирован' };
 
-    const tokenObj = await getAvailableToken();
+    // tokenObj может прийти от sendMessage — тогда создание чата и отправка
+    // идут под ОДНИМ аккаунтом (иначе round-robin создаст чат на одном
+    // аккаунте, а сообщение уйдёт под другим → «chat is not exist»).
+    if (!tokenObj) tokenObj = await getAvailableToken();
     if (tokenObj?.token) {
         authToken = tokenObj.token;
         logInfo(`Используется аккаунт для создания чата: ${tokenObj.id}`);
@@ -1054,7 +1064,7 @@ export async function createChatV2(model = DEFAULT_MODEL, title = 'Новый ч
         if (isTransient && retryCount < MAX_RETRY_COUNT) {
             logWarn(`Создание чата: ${result.status}, ретрай ${retryCount + 1}/${MAX_RETRY_COUNT} через ${RETRY_DELAY}мс...`);
             await delay(RETRY_DELAY);
-            return createChatV2(model, title, retryCount + 1, chatType);
+            return createChatV2(model, title, retryCount + 1, chatType, tokenObj);
         }
 
         const cleanError = isTransient

--- a/src/api/routes.js
+++ b/src/api/routes.js
@@ -593,7 +593,7 @@ function buildOpenAIToolResponse(result, mappedModel, toolCalls) {
         id: result.id || 'chatcmpl-' + Date.now(),
         object: 'chat.completion',
         created: Math.floor(Date.now() / 1000),
-        model: result.model || mappedModel || 'qwen-max-latest',
+        model: result.model || mappedModel || DEFAULT_MODEL,
         choices: [{
             index: 0,
             message: {
@@ -616,7 +616,7 @@ function writeToolCallsSse(res, mappedModel, result, toolCalls) {
         id: result.id || 'chatcmpl-stream',
         object: 'chat.completion.chunk',
         created: Math.floor(Date.now() / 1000),
-        model: result.model || mappedModel || 'qwen-max-latest'
+        model: result.model || mappedModel || DEFAULT_MODEL
     };
     res.write('data: ' + JSON.stringify({
         ...base,
@@ -757,7 +757,7 @@ router.post('/chat', async (req, res) => {
             logInfo(`История содержит ${allMessages.length} сообщений`);
         }
 
-        let mappedModel = model || "qwen-max-latest";
+        let mappedModel = model || DEFAULT_MODEL;
         if (model) {
             mappedModel = getMappedModel(model);
             if (mappedModel !== model) {
@@ -789,7 +789,7 @@ router.post('/chat', async (req, res) => {
                             id: 'chatcmpl-' + Date.now(),
                             object: 'chat.completion.chunk',
                             created: Math.floor(Date.now() / 1000),
-                            model: mappedModel || 'qwen-max-latest',
+                            model: mappedModel || DEFAULT_MODEL,
                             choices: [
                                 { index: 0, delta: { content: chunk }, finish_reason: null }
                             ]
@@ -818,7 +818,7 @@ router.post('/chat', async (req, res) => {
                         id: 'chatcmpl-' + Date.now(),
                         object: 'chat.completion.chunk',
                         created: Math.floor(Date.now() / 1000),
-                        model: mappedModel || 'qwen-max-latest',
+                        model: mappedModel || DEFAULT_MODEL,
                         choices: [
                             { index: 0, delta: { content: `Ошибка: ${result.error}` }, finish_reason: 'stop' }
                         ]
@@ -834,7 +834,7 @@ router.post('/chat', async (req, res) => {
                             id: 'chatcmpl-stream',
                             object: 'chat.completion.chunk',
                             created: Math.floor(Date.now() / 1000),
-                            model: mappedModel || 'qwen-max-latest',
+                            model: mappedModel || DEFAULT_MODEL,
                             choices: [
                                 { index: 0, delta: { content }, finish_reason: null }
                             ]
@@ -850,7 +850,7 @@ router.post('/chat', async (req, res) => {
                     id: 'chatcmpl-' + Date.now(),
                     object: 'chat.completion.chunk',
                     created: Math.floor(Date.now() / 1000),
-                    model: mappedModel || 'qwen-max-latest',
+                    model: mappedModel || DEFAULT_MODEL,
                     choices: [
                         { index: 0, delta: {}, finish_reason: 'stop' }
                     ]
@@ -864,7 +864,7 @@ router.post('/chat', async (req, res) => {
                     id: 'chatcmpl-stream',
                     object: 'chat.completion.chunk',
                     created: Math.floor(Date.now() / 1000),
-                    model: mappedModel || 'qwen-max-latest',
+                    model: mappedModel || DEFAULT_MODEL,
                     choices: [
                         { index: 0, delta: { content: 'Internal server error' }, finish_reason: 'stop' }
                     ]
@@ -1117,7 +1117,7 @@ router.post('/chat/completions', async (req, res) => {
             logDebug('OpenWebUI meta-запрос: используем отдельный чат (без привязки к сессии)');
         }
 
-        let mappedModel = model ? getMappedModel(model) : "qwen-max-latest";
+        let mappedModel = model ? getMappedModel(model) : DEFAULT_MODEL;
         if (model && mappedModel !== model) {
             logInfo(`Модель "${model}" заменена на "${mappedModel}"`);
         }
@@ -1164,7 +1164,7 @@ router.post('/chat/completions', async (req, res) => {
                             id: 'chatcmpl-stream',
                             object: 'chat.completion.chunk',
                             created: Math.floor(Date.now() / 1000),
-                            model: mappedModel || 'qwen-max-latest',
+                            model: mappedModel || DEFAULT_MODEL,
                             choices: [
                                 { index: 0, delta: { content: chunk }, finish_reason: null }
                             ]
@@ -1213,7 +1213,7 @@ router.post('/chat/completions', async (req, res) => {
                         id: 'chatcmpl-stream',
                         object: 'chat.completion.chunk',
                         created: Math.floor(Date.now() / 1000),
-                        model: mappedModel || 'qwen-max-latest',
+                        model: mappedModel || DEFAULT_MODEL,
                         choices: [
                             { index: 0, delta: { content: `Ошибка: ${result.error}` }, finish_reason: null }
                         ]
@@ -1229,7 +1229,7 @@ router.post('/chat/completions', async (req, res) => {
                             id: 'chatcmpl-stream',
                             object: 'chat.completion.chunk',
                             created: Math.floor(Date.now() / 1000),
-                            model: mappedModel || 'qwen-max-latest',
+                            model: mappedModel || DEFAULT_MODEL,
                             choices: [
                                 { index: 0, delta: { content }, finish_reason: null }
                             ]
@@ -1244,7 +1244,7 @@ router.post('/chat/completions', async (req, res) => {
                     id: 'chatcmpl-stream',
                     object: 'chat.completion.chunk',
                     created: Math.floor(Date.now() / 1000),
-                    model: mappedModel || 'qwen-max-latest',
+                    model: mappedModel || DEFAULT_MODEL,
                     choices: [
                         { index: 0, delta: {}, finish_reason: 'stop' }
                     ]
@@ -1258,7 +1258,7 @@ router.post('/chat/completions', async (req, res) => {
                     id: 'chatcmpl-stream',
                     object: 'chat.completion.chunk',
                     created: Math.floor(Date.now() / 1000),
-                    model: mappedModel || 'qwen-max-latest',
+                    model: mappedModel || DEFAULT_MODEL,
                     choices: [
                         { index: 0, delta: { content: 'Internal server error' }, finish_reason: 'stop' }
                     ]
@@ -1296,7 +1296,7 @@ router.post('/chat/completions', async (req, res) => {
                 id: result.id || "chatcmpl-" + Date.now(),
                 object: "chat.completion",
                 created: Math.floor(Date.now() / 1000),
-                model: result.model || mappedModel || "qwen-max-latest",
+                model: result.model || mappedModel || DEFAULT_MODEL,
                 choices: result.choices || [{
                     index: 0,
                     message: {
@@ -1442,7 +1442,7 @@ router.post('/v1/chat/completions', async (req, res) => {
             logDebug('OpenWebUI meta-запрос: используем отдельный чат (без привязки к сессии)');
         }
 
-        let mappedModel = model ? getMappedModel(model) : "qwen-max-latest";
+        let mappedModel = model ? getMappedModel(model) : DEFAULT_MODEL;
         if (model && mappedModel !== model) {
             logInfo(`Модель "${model}" заменена на "${mappedModel}"`);
         }
@@ -1492,7 +1492,7 @@ router.post('/v1/chat/completions', async (req, res) => {
                             id: 'chatcmpl-' + Date.now(),
                             object: 'chat.completion.chunk',
                             created: Math.floor(Date.now() / 1000),
-                            model: mappedModel || 'qwen-max-latest',
+                            model: mappedModel || DEFAULT_MODEL,
                             choices: [
                                 { index: 0, delta: { content: chunk }, finish_reason: null }
                             ]
@@ -1536,7 +1536,7 @@ router.post('/v1/chat/completions', async (req, res) => {
                         id: 'chatcmpl-stream',
                         object: 'chat.completion.chunk',
                         created: Math.floor(Date.now() / 1000),
-                        model: mappedModel || 'qwen-max-latest',
+                        model: mappedModel || DEFAULT_MODEL,
                         choices: [
                             { index: 0, delta: { content: `Ошибка: ${result.error}` }, finish_reason: 'stop' }
                         ]
@@ -1552,7 +1552,7 @@ router.post('/v1/chat/completions', async (req, res) => {
                             id: 'chatcmpl-stream',
                             object: 'chat.completion.chunk',
                             created: Math.floor(Date.now() / 1000),
-                            model: mappedModel || 'qwen-max-latest',
+                            model: mappedModel || DEFAULT_MODEL,
                             choices: [
                                 { index: 0, delta: { content }, finish_reason: null }
                             ]
@@ -1567,7 +1567,7 @@ router.post('/v1/chat/completions', async (req, res) => {
                     id: 'chatcmpl-stream',
                     object: 'chat.completion.chunk',
                     created: Math.floor(Date.now() / 1000),
-                    model: mappedModel || 'qwen-max-latest',
+                    model: mappedModel || DEFAULT_MODEL,
                     choices: [
                         { index: 0, delta: {}, finish_reason: 'stop' }
                     ]
@@ -1581,7 +1581,7 @@ router.post('/v1/chat/completions', async (req, res) => {
                     id: 'chatcmpl-stream',
                     object: 'chat.completion.chunk',
                     created: Math.floor(Date.now() / 1000),
-                    model: mappedModel || 'qwen-max-latest',
+                    model: mappedModel || DEFAULT_MODEL,
                     choices: [
                         { index: 0, delta: { content: 'Internal server error' }, finish_reason: 'stop' }
                     ]
@@ -1629,7 +1629,7 @@ router.post('/v1/chat/completions', async (req, res) => {
                 id: result.id || "chatcmpl-" + Date.now(),
                 object: "chat.completion",
                 created: Math.floor(Date.now() / 1000),
-                model: result.model || mappedModel || "qwen-max-latest",
+                model: result.model || mappedModel || DEFAULT_MODEL,
                 choices: [{
                     index: 0,
                     message: {

--- a/src/config.js
+++ b/src/config.js
@@ -48,7 +48,7 @@ export const USER_AGENT = process.env.USER_AGENT || 'Mozilla/5.0 (Windows NT 10.
 // ─── Сервер ──────────────────────────────────────────────────────────────────
 export const PORT = Number(process.env.PORT) || 3264;
 export const HOST = process.env.HOST || '0.0.0.0';
-export const DEFAULT_MODEL = process.env.DEFAULT_MODEL || 'qwen-max-latest';
+export const DEFAULT_MODEL = process.env.DEFAULT_MODEL || 'qwen3.7-max';
 export const ALLOW_UNSCOPED_SESSION_CHAT_RESTORE = toBoolean(process.env.ALLOW_UNSCOPED_SESSION_CHAT_RESTORE);
 
 // ─── Логирование ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## What & why

Two independent bugs that break out-of-the-box usage. Each is a separate commit.

### 1. Multi-account chat fails with "chat is not exist"

`createChatV2()` and `sendMessage()` each independently called the round-robin `getAvailableToken()`. With 2+ accounts configured, the chat was created under account A but the message was sent under account B, so Qwen rejected it:

```
Invalid input the chat <id> is not exist.
```

With a single account it happened to work because the pointer always returned the same token — which is why the multi-account round-robin (recommended in the README for rate limits) was effectively broken.

**Fix:** resolve the account once in `sendMessage()` and pass it into `createChatV2()`. On 401/429 retries (which switch accounts) reset `chatId`/`parentId` so a fresh chat is created under the new account.

### 2. Default model `qwen-max-latest` → "Model not found"

The default model was hardcoded as `qwen-max-latest` in `config.js` and in 22 places across `routes.js`. Qwen now returns `Model not found` for it, so any request that omits `model` fails. Routed all fallbacks through the existing `DEFAULT_MODEL` config value and updated its default to a current model (`qwen3.7-max`).

## Testing

- 4 accounts configured; repeated `/api/chat` and `/api/v1/chat/completions` requests now succeed (previously failed every time after the first chat).
- Requests without an explicit `model` now resolve to `qwen3.7-max` instead of failing.
- `node --check` passes on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
