### PR TITLE
docs: add .env.example documenting all environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,86 @@
+# FreeQwenApi — справочник переменных окружения.
+#
+# Переменные читаются напрямую из окружения процесса (process.env).
+# Автозагрузка файла .env в Node-приложении не настроена — задавайте значения
+# одним из способов:
+#   • локально (bash):       export PORT=3264 && npm start
+#   • локально (PowerShell):  $env:PORT=3264; npm start
+#   • docker-compose:         блок environment: в docker-compose.yml
+#   • docker run:             docker run -e PORT=3264 ...
+#
+# Все переменные опциональны — ниже указаны значения по умолчанию.
+# Файл можно скопировать в .env как личную шпаргалку (он в .gitignore).
+
+# ─── Сервер ──────────────────────────────────────────────────────────────────
+PORT=3264
+HOST=0.0.0.0
+DEFAULT_MODEL=qwen3.7-max
+# Разрешить восстановление чата из сессии без привязки к аккаунту (1/true/yes/on)
+ALLOW_UNSCOPED_SESSION_CHAT_RESTORE=false
+
+# ─── Запуск / меню аккаунтов ─────────────────────────────────────────────────
+# Пропустить интерактивное меню выбора аккаунта при старте (нужно для headless/CI/Docker)
+SKIP_ACCOUNT_MENU=false
+# Полностью неинтерактивный режим (не запрашивать ввод в консоли)
+NON_INTERACTIVE=false
+
+# ─── Лимиты ──────────────────────────────────────────────────────────────────
+# Фолбэк-длительность блокировки токена по rate-limit (часы), когда Qwen не
+# прислал точное значение. Реализуется отдельным улучшением (feat/qwen-ratelimit-env).
+QWEN_RATELIMIT_HOURS=24
+MAX_RETRY_COUNT=3
+MAX_HISTORY_LENGTH=100
+MAX_FILE_SIZE=10485760
+PAGE_POOL_SIZE=3
+TASK_POLL_MAX_ATTEMPTS=90
+TASK_POLL_INTERVAL=2000
+
+# ─── Таймауты (мс) ───────────────────────────────────────────────────────────
+PAGE_TIMEOUT=120000
+AUTH_TIMEOUT=120000
+NAVIGATION_TIMEOUT=60000
+RETRY_DELAY=2000
+STREAMING_CHUNK_DELAY=20
+
+# ─── Пути (относительно корня проекта) ───────────────────────────────────────
+SESSION_DIR=session
+UPLOADS_DIR=uploads
+LOGS_DIR=logs
+
+# ─── Браузер ─────────────────────────────────────────────────────────────────
+# Путь к исполняемому файлу Chrome/Chromium. В Docker задаётся = /usr/bin/chromium.
+CHROME_PATH=
+VIEWPORT_WIDTH=1920
+VIEWPORT_HEIGHT=1080
+USER_AGENT=Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36
+
+# ─── Логирование ─────────────────────────────────────────────────────────────
+LOG_LEVEL=info
+LOG_MAX_SIZE=5242880
+LOG_MAX_FILES=5
+
+# ─── Генерация изображений/видео (опционально) ───────────────────────────────
+# Прямой ключ DashScope для image/video API. Не обязателен: есть browser-based
+# генерация через Qwen Chat. Оставьте пустым, если не используете DashScope.
+DASHSCOPE_API_KEY=
+
+# ─── Адреса Qwen (продвинутое — обычно менять не нужно) ───────────────────────
+# Остальные URL по умолчанию выводятся из QWEN_BASE_URL.
+QWEN_BASE_URL=https://chat.qwen.ai
+# CHAT_API_URL=
+# CREATE_CHAT_URL=
+# CHAT_PAGE_URL=
+# TASK_STATUS_URL=
+# STS_TOKEN_API_URL=
+# AUTH_SIGNIN_URL=
+# OSS_SDK_URL=https://gosspublic.alicdn.com/aliyun-oss-sdk-6.20.0.min.js
+
+# ─── Скрипты обслуживания (опционально) ──────────────────────────────────────
+# scripts/sync_models.js — синхронизация списка моделей
+# QWEN_CHAT_URL=
+# QWEN_MODELS_FILE=
+# QWEN_MODELS_DOC=
+# scripts/smoke_test.js — дымовой тест API
+# QWEN_PROXY_BASE_URL=http://localhost:3264
+# QWEN_PROXY_SMOKE_MODEL=
+# QWEN_PROXY_API_KEY=

--- a/README.md
+++ b/README.md
@@ -52,6 +52,19 @@ npm run smoke
 http://localhost:3264/api
 ```
 
+## Конфигурация
+
+Все настройки задаются переменными окружения. Полный список с дефолтами и комментариями — в [`.env.example`](.env.example): порт, модель по умолчанию, таймауты, лимиты, пути, логирование, путь к Chrome и т.д.
+
+Переменные читаются из окружения процесса. Задайте нужные удобным способом:
+
+```bash
+export PORT=3264 DEFAULT_MODEL=qwen3.7-max   # bash
+$env:PORT=3264; npm start                    # PowerShell
+```
+
+либо через блок `environment:` в `docker-compose.yml` / флаги `-e` у `docker run`.
+
 ## Авторизация Qwen Chat
 
 Добавить аккаунт:


### PR DESCRIPTION
## What
Adds a reference `.env.example` listing every supported environment variable (server, limits, timeouts, paths, browser, logging, image generation) with defaults and comments, plus a **Конфигурация** section in the README linking to it.

## Why
All ~30 env vars currently live only in `src/config.js` (plus a few read in `index.js`/scripts), so they aren't discoverable for self-hosters. This makes configuration self-documenting.

## Notes
- Variables are read directly from `process.env` (there is no `.env` autoloader); the file documents shell / docker-compose configuration, and the header states this explicitly so it isn't misleading.
- Docs only — no code changes, no new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
