### PR TITLE
feat: make rate-limit cooldown hours configurable via env

### DIFF
--- a/src/api/chat.js
+++ b/src/api/chat.js
@@ -12,7 +12,8 @@ import {
     CHAT_API_URL, CREATE_CHAT_URL, CHAT_PAGE_URL, TASK_STATUS_URL,
     PAGE_TIMEOUT, RETRY_DELAY, PAGE_POOL_SIZE,
     DEFAULT_MODEL, MAX_RETRY_COUNT,
-    TASK_POLL_MAX_ATTEMPTS, TASK_POLL_INTERVAL
+    TASK_POLL_MAX_ATTEMPTS, TASK_POLL_INTERVAL,
+    RATE_LIMIT_HOURS
 } from '../config.js';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -738,10 +739,10 @@ async function handleApiError(response, tokenObj, message, model, chatId, parent
     }
 
     if (response.status === 429 || (response.errorBody && response.errorBody.includes('RateLimited'))) {
-        let hours = 24;
+        let hours = RATE_LIMIT_HOURS;
         try {
             const rateInfo = JSON.parse(response.errorBody);
-            hours = Number(rateInfo.num) || 24;
+            hours = Number(rateInfo.num) || RATE_LIMIT_HOURS;
         } catch { /* errorBody might not be valid JSON */ }
 
         if (tokenObj?.id === 'browser') {

--- a/src/api/tokenManager.js
+++ b/src/api/tokenManager.js
@@ -2,7 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { logError } from '../logger/index.js';
-import { SESSION_DIR, ACCOUNTS_DIR } from '../config.js';
+import { SESSION_DIR, ACCOUNTS_DIR, RATE_LIMIT_HOURS } from '../config.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -53,7 +53,7 @@ export function hasValidTokens() {
     return tokens.some(t => (!t.resetAt || new Date(t.resetAt).getTime() <= now) && !t.invalid);
 }
 
-export function markRateLimited(id, hours = 24) {
+export function markRateLimited(id, hours = RATE_LIMIT_HOURS) {
     const tokens = loadTokens();
     const idx = tokens.findIndex(t => t.id === id);
     if (idx !== -1) {

--- a/src/config.js
+++ b/src/config.js
@@ -33,6 +33,8 @@ export const MAX_HISTORY_LENGTH = Number(process.env.MAX_HISTORY_LENGTH) || 100;
 export const MAX_RETRY_COUNT = Number(process.env.MAX_RETRY_COUNT) || 3;
 export const TASK_POLL_MAX_ATTEMPTS = Number(process.env.TASK_POLL_MAX_ATTEMPTS) || 90;
 export const TASK_POLL_INTERVAL = Number(process.env.TASK_POLL_INTERVAL) || 2_000;
+// Фолбэк-длительность блокировки токена по rate-limit (часы), когда Qwen не прислал точное значение в ответе.
+export const RATE_LIMIT_HOURS = Number(process.env.QWEN_RATELIMIT_HOURS) || 24;
 
 // ─── Пути (относительно корня проекта) ───────────────────────────────────────
 export const SESSION_DIR = process.env.SESSION_DIR || 'session';


### PR DESCRIPTION
## What
Extracts the hardcoded `24`-hour rate-limit fallback into a named `RATE_LIMIT_HOURS` constant in `config.js`, sourced from `QWEN_RATELIMIT_HOURS` (default `24`).

## Why
When Qwen returns a rate-limit without an explicit duration, the cooldown was hardcoded to 24h in three places (`chat.js` ×2 and the `markRateLimited` default in `tokenManager.js`). Making it configurable lets operators tune recovery time.

## Changes
- `config.js`: `export const RATE_LIMIT_HOURS = Number(process.env.QWEN_RATELIMIT_HOURS) || 24;`
- `chat.js`: use the constant for the 429 fallback hours
- `tokenManager.js`: `markRateLimited` default uses the constant

Behavior is unchanged by default (still 24h). Verified the env override resolves (`2` → 2, invalid → fallback 24).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
