### PR TITLE
fix(chatHistory): sanitize chatId to prevent path traversal (CWE-22)

### DIFF
--- a/src/api/chatHistory.js
+++ b/src/api/chatHistory.js
@@ -33,8 +33,33 @@ export function createChat(chatName) {
     return chatId;
 }
 
+/**
+ * Sanitize chatId to prevent path traversal (CWE-22).
+ * Rejects any value containing path separators, traversal sequences,
+ * or characters outside the allowed set [a-zA-Z0-9_-].
+ * Returns null for invalid values — callers must handle null gracefully.
+ */
+function sanitizeChatId(chatId) {
+    if (typeof chatId !== 'string' || !chatId) return null;
+    // Reject if it contains path separators or traversal sequences
+    if (chatId.includes('/') || chatId.includes('\\') || chatId.includes('..')) return null;
+    // Whitelist: only allow alphanumeric, hyphens, and underscores
+    if (!/^[a-zA-Z0-9_-]+$/.test(chatId)) return null;
+    return chatId;
+}
+
 function getHistoryFilePath(chatId) {
-    return path.join(HISTORY_DIR, `${chatId}.json`);
+    const safeChatId = sanitizeChatId(chatId);
+    if (!safeChatId) {
+        throw new Error(`Invalid chatId: ${String(chatId).substring(0, 50)}`);
+    }
+    const filePath = path.join(HISTORY_DIR, `${safeChatId}.json`);
+    // Defense-in-depth: verify the resolved path is still inside HISTORY_DIR
+    const resolved = path.resolve(filePath);
+    if (!resolved.startsWith(path.resolve(HISTORY_DIR) + path.sep)) {
+        throw new Error(`Path traversal blocked for chatId: ${String(chatId).substring(0, 50)}`);
+    }
+    return filePath;
 }
 
 export function saveHistory(chatId, data) {
@@ -120,10 +145,15 @@ export function loadHistory(chatId) {
 }
 
 export function chatExists(chatId) {
-    const historyFilePath = getHistoryFilePath(chatId);
-    const exists = fs.existsSync(historyFilePath);
-    logDebug(`Проверка существования чата ${chatId}: ${exists ? 'найден' : 'не найден'}`);
-    return exists;
+    try {
+        const historyFilePath = getHistoryFilePath(chatId);
+        const exists = fs.existsSync(historyFilePath);
+        logDebug(`Проверка существования чата ${chatId}: ${exists ? 'найден' : 'не найден'}`);
+        return exists;
+    } catch (error) {
+        logError(`Invalid chatId in chatExists: ${error.message}`);
+        return false;
+    }
 }
 
 export function renameChat(chatId, newName) {
@@ -341,4 +371,4 @@ export function deleteChatsAutomatically(criteria = {}) {
             error: error.message
         };
     }
-} 
+}


### PR DESCRIPTION
## Summary

This PR fixes a path traversal vulnerability (CWE-22) in `src/api/chatHistory.js` where user-supplied `chatId` values flow unsanitized into filesystem operations via `path.join()`. An attacker who can reach the API could craft a `chatId` containing directory traversal sequences (e.g., `../../etc/passwd`) to read or write files outside the intended chat history directory.

## Vulnerability Details

**Affected function:** `getHistoryFilePath()` in `src/api/chatHistory.js`
**CWE:** [CWE-22 — Improper Limitation of a Pathname to a Restricted Directory](https://cwe.mitre.org/data/definitions/22.html)
**Severity:** Medium (defense-in-depth — see Exploitability below)

### Data Flow

1. User sends a POST request to `/api/chat`, `/api/chat/completions`, or `/api/v1/chat/completions` with a `chatId` in the JSON body (`req.body.chatId` — see `routes.js` lines 728, 1019, 1343).
2. This `chatId` is passed to `sendMessage()` in `chat.js`, which echoes it back in `result.chatId`.
3. After a successful response, `routes.js` calls `loadHistory(result.chatId)` and `saveHistory(result.chatId, ...)` (lines 887, 892, 1320, 1326, 1665, 1671).
4. Both functions call `getHistoryFilePath(chatId)`, which previously did a bare `path.join(HISTORY_DIR, chatId + '.json')` with no validation at all.

A `chatId` like `../../../tmp/evil` would resolve to a path outside `HISTORY_DIR`.

### Exploitability Assessment

Currently, direct exploitation is **mitigated indirectly** by the Qwen API: `sendMessage()` creates or validates a chat session with Qwen's backend, and a traversal string like `../../etc/passwd` would likely be rejected by Qwen as an invalid chat ID. The route handlers also have error guards (`if (result.choices && ...)`) that prevent `loadHistory`/`saveHistory` from being called when `sendMessage` returns an error.

However, relying on a third-party API for input validation is not a proper security boundary — Qwen's validation behavior could change at any time. Additionally, the `/api/chats/:chatId/history` endpoints at lines 1724 and 1750 accept `chatId` from `req.params`, meaning those routes could be affected if they interact with file operations in the future.

Before submitting, we attempted to disprove this finding: we verified whether auth middleware, error guards, or Qwen's API validation would fully prevent exploitation. Auth middleware exists at line 312 of `routes.js` (`router.use(authMiddleware)`), but it's conditionally applied — when `Authorization.txt` is empty, authentication is completely disabled (a documented option). CORS is `Access-Control-Allow-Origin: *` and the server binds `0.0.0.0` by default. While the Qwen API's rejection of invalid chat IDs currently prevents the dangerous code path from executing end-to-end, this is an accidental mitigation from a third party, not a deliberate security control.

## Proof of Concept

```bash
# Against a running FreeQwenApi instance with auth disabled (empty Authorization.txt):

# Attempt path traversal via /api/chat endpoint
curl -X POST http://localhost:3264/api/chat \
  -H "Content-Type: application/json" \
  -d '{
    "message": "hello",
    "model": "qwen-plus-latest",
    "chatId": "../../etc/passwd"
  }'

# Without this fix, getHistoryFilePath() resolves the chatId to a path
# outside HISTORY_DIR. The traversal string passes through path.join()
# and could target arbitrary filesystem locations if sendMessage()
# returns successfully.
#
# With the fix, sanitizeChatId() rejects the input immediately:
#   - It fails the path separator check (contains '/')
#   - It fails the whitelist regex /^[a-zA-Z0-9_-]+$/
#   - getHistoryFilePath() throws "Invalid chatId"
```

## Fix Description

The fix adds a `sanitizeChatId()` function and a defense-in-depth path resolution check in `getHistoryFilePath()`:

1. **Input validation** — `sanitizeChatId()` rejects any `chatId` that:
   - Is not a string or is empty
   - Contains path separators (`/` or `\`) or traversal sequences (`..`)
   - Contains characters outside the whitelist `[a-zA-Z0-9_-]`

2. **Path resolution check** — After `path.join()`, the resolved absolute path is verified to be inside `HISTORY_DIR`. This is a defense-in-depth measure in case the whitelist is ever relaxed.

3. **Graceful error handling** — `chatExists()` now catches validation errors and returns `false` instead of crashing, since it may be called with untrusted input.

The fix is placed in the centralized `getHistoryFilePath()` function, which means all callers (`saveHistory`, `loadHistory`, `chatExists`, `renameChat`, `deleteChat`) are automatically protected.

## Testing

- Verified that valid chatIds (alphanumeric with hyphens/underscores) pass through `sanitizeChatId()` and `getHistoryFilePath()` unchanged.
- Verified that traversal payloads (`../../../etc/passwd`, `..\\windows\\system32`, `....//....//etc/passwd`) are rejected by `sanitizeChatId()`.
- Verified that `chatExists()` returns `false` (not an exception) for invalid chatIds.
- Verified the diff is minimal — only `src/api/chatHistory.js` is modified (1 file, 36 insertions, 6 deletions).

---

<sub>_Submitted by Sebastion — autonomous open-source security research from [Foundation Machines](https://foundationmachines.ai). Free for public repos via the [Sebastion AI GitHub App](https://github.com/apps/sebastionai)._</sub>
