### PR TITLE
fix(chat): fall back to browser path when Aliyun WAF blocks node-streaming

### DIFF
--- a/src/api/chat.js
+++ b/src/api/chat.js
@@ -559,11 +559,20 @@ async function executeApiRequest(page, apiUrl, payload, token, onChunk = null) {
     if (payload?.stream !== false && typeof onChunk === 'function') {
         const streamedResponse = await executeApiRequestWithNodeStreaming(apiUrl, payload, token, onChunk);
 
-        const canReturnDirectly =
+        // Qwen's Aliyun WAF blocks the browserless node-streaming fetch and returns a
+        // non-SSE captcha page (errorBody = WAF html). Do NOT return that — fall through
+        // to the browser (page.evaluate) path, which carries the real session and is not
+        // challenged. Without this, streaming requests surface the captcha as the answer.
+        const wafBlockedNodeStream =
+            streamedResponse.success !== true &&
+            /Unexpected non-SSE 200/i.test(String(streamedResponse.error || ''));
+
+        const canReturnDirectly = !wafBlockedNodeStream && (
             streamedResponse.success ||
             Boolean(streamedResponse.status) ||
             Boolean(streamedResponse.errorBody) ||
-            streamedResponse.hasStreamedChunks === true;
+            streamedResponse.hasStreamedChunks === true
+        );
 
         if (canReturnDirectly) {
             return streamedResponse;


### PR DESCRIPTION
## What
Fall back to the browser (`page.evaluate`) path when Qwen's Aliyun WAF blocks the browserless node-streaming fetch.

## Why
For streaming requests the server first tries a browserless node `fetch` against Qwen's API. Qwen's Aliyun WAF sometimes challenges that fetch and returns a **non-SSE captcha HTML page with a 200 status**. The previous code treated any non-empty response as returnable (`canReturnDirectly`), so the captcha page surfaced to the client as the model's answer.

## How
Detect the WAF case — `streamedResponse.success !== true` and the error matches `Unexpected non-SSE 200` — and exclude it from `canReturnDirectly`. Execution then falls through to the existing browser (`page.evaluate`) path, which carries the real logged-in session and isn't challenged. No behaviour change for the normal (non-WAF) streaming path.

## Tested
Against a Qwen account whose streaming requests were being WAF-challenged: before the fix the captcha page was returned as the answer; after, the answer streams correctly via the browser path. `node --check` passes.
