### PR TITLE
feat(browser): QWEN_VISIBLE (headed) and QWEN_CDP_URL (attach to running Chrome) auth modes

### DIFF
--- a/index.js
+++ b/index.js
@@ -167,7 +167,11 @@ async function startServer() {
         ensureNonInteractiveTokens();
     }
 
-    const browserInitialized = await initBrowser(false);
+    // Qwen blocks headless automation (CDP evaluate hangs). Allow a headed run
+    // via QWEN_VISIBLE=1 so the page renders normally and any one-time
+    // verification can be passed; the session then persists.
+    const visibleMode = ['1', 'true', 'yes', 'on'].includes(String(process.env.QWEN_VISIBLE || '').toLowerCase());
+    const browserInitialized = await initBrowser(visibleMode);
     if (!browserInitialized) {
         logError('Не удалось инициализировать браузер. Завершение работы.');
         process.exit(1);

--- a/src/browser/browser.js
+++ b/src/browser/browser.js
@@ -23,29 +23,45 @@ const delay = (ms) => new Promise(resolve => setTimeout(resolve, ms));
 export async function initBrowser(visibleMode = true, skipManualRestart = false) {
     if (browserInstance) return true;
 
-    logInfo('Инициализация браузера с Puppeteer Stealth...');
+    const cdpUrl = (process.env.QWEN_CDP_URL || '').trim();
+    logInfo(cdpUrl
+        ? `Инициализация браузера: подключение к Chrome по CDP (${cdpUrl})...`
+        : 'Инициализация браузера с Puppeteer Stealth...');
     try {
-        browserInstance = await puppeteer.launch({
-            headless: !visibleMode,
-            slowMo: visibleMode ? 30 : 0,
-            executablePath: process.env.CHROME_PATH || undefined,
-            args: [
-                '--no-sandbox', '--disable-setuid-sandbox',
-                '--disable-blink-features=AutomationControlled',
-                '--disable-dev-shm-usage', '--disable-web-security',
-                '--disable-features=IsolateOrigins,site-per-process',
-                `--window-size=${VIEWPORT_WIDTH},${VIEWPORT_HEIGHT}`,
-                '--start-maximized', '--disable-infobars',
-                '--disable-extensions', '--disable-gpu',
-                '--no-first-run', '--no-default-browser-check',
-                '--ignore-certificate-errors', '--ignore-certificate-errors-spki-list'
-            ],
-            defaultViewport: { width: VIEWPORT_WIDTH, height: VIEWPORT_HEIGHT },
-            ignoreHTTPSErrors: true
-        });
+        if (cdpUrl) {
+            // Attach to YOUR already-running, logged-in Chrome (launch it with
+            // --remote-debugging-port=PORT --user-data-dir=<dir>). Reuses a
+            // human-trusted session, so qwen serves no captcha and the headless
+            // CDP evaluate no longer hangs — no empty-browser login required.
+            browserInstance = await puppeteer.connect({
+                browserURL: cdpUrl,
+                defaultViewport: { width: VIEWPORT_WIDTH, height: VIEWPORT_HEIGHT }
+            });
+        } else {
+            browserInstance = await puppeteer.launch({
+                headless: !visibleMode,
+                slowMo: visibleMode ? 30 : 0,
+                executablePath: process.env.CHROME_PATH || undefined,
+                args: [
+                    '--no-sandbox', '--disable-setuid-sandbox',
+                    '--disable-blink-features=AutomationControlled',
+                    '--disable-dev-shm-usage', '--disable-web-security',
+                    '--disable-features=IsolateOrigins,site-per-process',
+                    `--window-size=${VIEWPORT_WIDTH},${VIEWPORT_HEIGHT}`,
+                    '--start-maximized', '--disable-infobars',
+                    '--disable-extensions', '--disable-gpu',
+                    '--no-first-run', '--no-default-browser-check',
+                    '--ignore-certificate-errors', '--ignore-certificate-errors-spki-list'
+                ],
+                defaultViewport: { width: VIEWPORT_WIDTH, height: VIEWPORT_HEIGHT },
+                ignoreHTTPSErrors: true
+            });
+        }
 
-        const pages = await browserInstance.pages();
-        const page = pages.length > 0 ? pages[0] : await browserInstance.newPage();
+        // In CDP mode open a fresh tab (don't hijack the user's current tab).
+        const page = cdpUrl
+            ? await browserInstance.newPage()
+            : ((await browserInstance.pages())[0] || await browserInstance.newPage());
 
         await page.setUserAgent(USER_AGENT);
         await page.setViewport({ width: VIEWPORT_WIDTH, height: VIEWPORT_HEIGHT, deviceScaleFactor: 1 });
@@ -101,7 +117,9 @@ export async function initBrowser(visibleMode = true, skipManualRestart = false)
         browserContext = page;
         logInfo('Браузер инициализирован с максимальной защитой от обнаружения');
 
-        if (visibleMode) {
+        // CDP-connected Chrome is already a real, logged-in session — skip the
+        // interactive empty-browser login/captcha flow.
+        if (visibleMode && !cdpUrl) {
             await startManualAuthenticationPuppeteer(page, skipManualRestart);
         }
         // loadSessionPuppeteer removed — was dead code (always returned false)


### PR DESCRIPTION
## What
Two opt-in environment variables for establishing the browser session used for Qwen auth:

- **`QWEN_VISIBLE=1`** — run the browser headed instead of headless.
- **`QWEN_CDP_URL`** — attach to an already-running, logged-in Chrome over CDP instead of launching a fresh one.

## Why
Qwen blocks headless automation: the headless CDP `evaluate` can hang, and a first-time login can hit a one-time verification that a blank automated browser can't pass. That makes initial authentication unreliable.

- Headed mode lets the page render normally so any one-time verification can be completed by hand; the session then persists to `session/`.
- Attaching to your own Chrome (launched with `--remote-debugging-port=PORT --user-data-dir=<dir>`) reuses a human-trusted session — Qwen serves no captcha and the headless `evaluate` no longer hangs, so no empty-browser login is needed at all.

## How
- `index.js`: read `QWEN_VISIBLE` and pass it as the `visibleMode` flag to `initBrowser`.
- `browser/browser.js`: when `QWEN_CDP_URL` is set, `puppeteer.connect({ browserURL })` instead of `puppeteer.launch(...)`; open a fresh tab (don't hijack the user's current one); and skip the interactive empty-browser login flow since a CDP-connected Chrome is already a real logged-in session.

Both default off — with neither var set, behaviour is identical to before.

## Tested
- Default (no vars): unchanged headless launch.
- `QWEN_VISIBLE=1`: browser opens headed, one-time verification can be passed, session persists.
- `QWEN_CDP_URL=http://127.0.0.1:9222`: attaches to a running logged-in Chrome, opens a new tab, serves requests with no captcha. `node --check` passes on both files.
