### PR TITLE
feat(accounts): human-readable account labels

### DIFF
--- a/src/api/routes.js
+++ b/src/api/routes.js
@@ -12,7 +12,7 @@ import multer from 'multer';
 import path from 'path';
 import fs from 'fs';
 import crypto from 'crypto';
-import { listTokens, markInvalid, markRateLimited, markValid, addTokenFromString, deleteAccount, decodeTokenInfo, updateAccountToken } from './tokenManager.js';
+import { listTokens, markInvalid, markRateLimited, markValid, addTokenFromString, deleteAccount, decodeTokenInfo, updateAccountToken, setLabel } from './tokenManager.js';
 import { FORGETMEAI_WATERMARK } from '../utils/branding.js';
 
 // Функция для генерирования детерминированного chatId на основе истории
@@ -1094,6 +1094,7 @@ router.get('/accounts', localOnly, sameOriginOnly, (req, res) => {
             else if (info.exp && info.exp < now) status = 'EXPIRED';
             return {
                 id: t.id,
+                label: t.label || '',
                 status,
                 exp: info.exp,
                 resetAt: t.resetAt || null,
@@ -1111,7 +1112,7 @@ router.post('/accounts', localOnly, sameOriginOnly, (req, res) => {
     try {
         const token = req.body?.token;
         if (!token) return res.status(400).json({ error: 'Не передан token' });
-        const result = addTokenFromString(token);
+        const result = addTokenFromString(token, req.body?.label);
         if (result.error) return res.status(400).json(result);
         logInfo(`Добавлен аккаунт через дашборд: ${result.id}`);
         res.json({ ok: true, id: result.id });
@@ -1164,6 +1165,19 @@ router.post('/accounts/:id/update', localOnly, sameOriginOnly, (req, res) => {
         res.json(result);
     } catch (error) {
         logError('Ошибка обновления токена аккаунта', error);
+        res.status(500).json({ error: 'Внутренняя ошибка сервера' });
+    }
+});
+
+// Установить/изменить человекочитаемый ярлык аккаунта (для различения в пуле).
+router.post('/accounts/:id/label', localOnly, sameOriginOnly, (req, res) => {
+    try {
+        const result = setLabel(req.params.id, req.body?.label);
+        if (result.error) return res.status(400).json(result);
+        logInfo(`Изменён ярлык аккаунта через дашборд: ${req.params.id}`);
+        res.json(result);
+    } catch (error) {
+        logError('Ошибка изменения ярлыка аккаунта', error);
         res.status(500).json({ error: 'Внутренняя ошибка сервера' });
     }
 });

--- a/src/api/tokenManager.js
+++ b/src/api/tokenManager.js
@@ -85,6 +85,21 @@ export function markValid(id, newToken) {
     }
 }
 
+// Устанавливает человекочитаемый ярлык аккаунта (для различения в пуле).
+// Пустая строка очищает ярлык. Возвращает { ok, id, label } либо { error }.
+export function setLabel(id, rawLabel) {
+    if (typeof id !== 'string' || !/^acc_[a-zA-Z0-9]+$/.test(id)) {
+        return { error: 'Некорректный id аккаунта' };
+    }
+    const label = String(rawLabel ?? '').trim().slice(0, 60);
+    const tokens = loadTokens();
+    const idx = tokens.findIndex(t => t.id === id);
+    if (idx === -1) return { error: 'Аккаунт не найден' };
+    tokens[idx].label = label;
+    saveTokens(tokens);
+    return { ok: true, id, label };
+}
+
 // Обновляет токен существующего аккаунта (relogin из дашборда):
 // markValid (обновляет token + сбрасывает invalid/resetAt) + перезапись token.txt.
 export function updateAccountToken(id, rawToken) {
@@ -132,7 +147,7 @@ export function decodeTokenInfo(token) {
 
 // Добавляет токен вручную (из дашборда), без запуска браузера.
 // Возвращает { id } при успехе либо { error }.
-export function addTokenFromString(rawToken) {
+export function addTokenFromString(rawToken, label) {
     const token = String(rawToken || '').trim();
     if (!token.startsWith('eyJ') || token.split('.').length !== 3) {
         return { error: 'Невалидный токен: ожидается JWT (eyJ...)' };
@@ -150,7 +165,7 @@ export function addTokenFromString(rawToken) {
     fs.mkdirSync(accDir, { recursive: true });
     fs.writeFileSync(path.join(accDir, 'token.txt'), token, 'utf8');
 
-    tokens.push({ id, token, resetAt: null });
+    tokens.push({ id, token, resetAt: null, label: String(label || '').trim().slice(0, 60) });
     saveTokens(tokens);
     return { id };
 }

--- a/src/dashboard/index.html
+++ b/src/dashboard/index.html
@@ -98,6 +98,7 @@
   .acc.OK{border-left-color:var(--ok)} .acc.WAIT{border-left-color:var(--warn)}
   .acc.INVALID,.acc.EXPIRED,.acc.ERROR{border-left-color:var(--err)}
   .acc .id{font-weight:600;font-size:var(--fs-sm)}
+  .acc .acclabel{font-size:var(--fs-xs);color:var(--accent);background:var(--card);border:1px solid var(--border);border-radius:999px;padding:1px 8px}
   .acc .meta{color:var(--muted);font-size:var(--fs-xs);font-family:var(--mono)}
   .badge{font-size:var(--fs-xs);font-weight:700;padding:3px 9px;border-radius:4px;display:inline-flex;align-items:center;gap:5px}
   .badge::before{content:"";width:6px;height:6px;border-radius:50%;background:currentColor}
@@ -375,15 +376,20 @@ async function loadAccounts(){
     list.innerHTML=j.accounts.map(a=>{
       const meta=a.resetAt?('лимит до '+fmtTime(a.resetAt)):fmtExp(a.exp);
       return `<div class="acc ${a.status}" data-id="${esc(a.id)}">
-        <span class="id">${esc(a.id)}</span><span class="badge ${a.status}">${stLabel(a.status)}</span>
+        <span class="id">${esc(a.id)}</span><span class="badge ${a.status}">${stLabel(a.status)}</span>${a.label?`<span class="acclabel">${esc(a.label)}</span>`:''}
         <span class="meta">${esc(a.preview||'')}</span><span class="meta">${esc(meta)}</span><span class="spacer"></span>
         <button class="sm" data-check="${esc(a.id)}" aria-label="Проверить ${esc(a.id)}">${icon('i-check')}проверить</button>
+        <button class="sm" data-editlabel="${esc(a.id)}" aria-label="Ярлык ${esc(a.id)}">ярлык</button>
         <button class="sm" data-relogin="${esc(a.id)}" aria-label="Обновить токен ${esc(a.id)}">${icon('i-key')}токен</button>
         <button class="sm danger" data-del="${esc(a.id)}" aria-label="Удалить ${esc(a.id)}">${icon('i-trash')}</button>
       </div>
       <div class="relogin-box" data-box="${esc(a.id)}" style="display:none">
         <input type="text" aria-label="Новый токен для ${esc(a.id)}" placeholder="Новый токен Qwen (eyJ…)" data-newtok="${esc(a.id)}" autocomplete="off" spellcheck="false">
         <button class="primary sm" data-save="${esc(a.id)}">Сохранить</button><button class="sm" data-cancel="${esc(a.id)}">Отмена</button>
+      </div>
+      <div class="relogin-box" data-labelbox="${esc(a.id)}" style="display:none">
+        <input type="text" maxlength="60" aria-label="Ярлык для ${esc(a.id)}" placeholder="Ярлык — для различения аккаунтов" data-newlabel="${esc(a.id)}" value="${esc(a.label||'')}" autocomplete="off">
+        <button class="primary sm" data-savelabel="${esc(a.id)}">Сохранить</button><button class="sm" data-cancellabel="${esc(a.id)}">Отмена</button>
       </div>`;
     }).join('');
   }catch{ list.innerHTML='<div class="hint err-text">Не удалось загрузить аккаунты</div>'; }
@@ -419,6 +425,12 @@ document.addEventListener('click', async e=>{
     if(!token) return toast('Вставьте токен','err'); t.disabled=true;
     try{ const j=await (await fetch(origin+'/api/accounts/'+encodeURIComponent(id)+'/update',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({token})})).json();
       if(j.ok){ toast('Токен обновлён: '+id,'ok'); loadAccounts(); loadHealth(); } else { toast(j.error||'Ошибка','err'); t.disabled=false; } }
+    catch{ toast('Сеть недоступна','err'); t.disabled=false; } return; }
+  if(t.dataset.editlabel){ const b=document.querySelector('[data-labelbox="'+CSS.escape(t.dataset.editlabel)+'"]'); if(b){ b.style.display='flex'; const i=b.querySelector('input'); if(i){ i.focus(); i.select(); } } return; }
+  if(t.dataset.cancellabel){ const b=document.querySelector('[data-labelbox="'+CSS.escape(t.dataset.cancellabel)+'"]'); if(b) b.style.display='none'; return; }
+  if(t.dataset.savelabel){ const id=t.dataset.savelabel, inp=document.querySelector('[data-newlabel="'+CSS.escape(id)+'"]'); const label=(inp?.value||'').trim(); t.disabled=true;
+    try{ const j=await (await fetch(origin+'/api/accounts/'+encodeURIComponent(id)+'/label',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({label})})).json();
+      if(j.ok){ toast('Ярлык сохранён','ok'); loadAccounts(); } else { toast(j.error||'Ошибка','err'); t.disabled=false; } }
     catch{ toast('Сеть недоступна','err'); t.disabled=false; } return; }
 });
 setInterval(()=>{ if($('#tab-overview').classList.contains('active') && inited.overview) loadAccounts(); }, 20000);


### PR DESCRIPTION
## What
Optional **human-readable labels** for Qwen accounts, so several accounts in the pool can be told apart at a glance (e.g. "personal", "work", "spare").

## Why
The dashboard identifies accounts only by `acc_N` id and a masked token preview. With more than a couple of accounts that's hard to read. A short freeform label makes the pool manageable.

## How
- **`tokenManager.js`**: `setLabel(id, label)` — validates the id, trims and caps the label at 60 chars (blank string clears it), persists to `tokens.json`. `addTokenFromString` gains an optional `label` so a label can be set at add time.
- **`routes.js`**: `GET /api/accounts` includes `label` in each row; new `POST /api/accounts/:id/label` sets it — behind the same `localOnly` + `sameOriginOnly` guards as the other account-management routes.
- **`dashboard/index.html`**: a label chip on each account row and an inline "ярлык" editor box, wired through the existing delegated click handler (same pattern as the relogin box) and styled with the dashboard's existing CSS tokens. No new dependencies.

Fully optional and backward-compatible: accounts without a label render exactly as before, and `tokens.json` entries without a `label` field keep working.

## Tested
- Add/edit/clear a label from the dashboard → persists across reloads; `GET /api/accounts` returns it.
- `node --check` passes on `routes.js` and `tokenManager.js`; the dashboard's inline script parses clean.
- Label routes reject non-local / cross-origin requests via the existing guards.
